### PR TITLE
Make work with clang 4 or higher. macOS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 # EasySXB Makefile
 #
-# Static builds require that the fltk-1.3.3 source
+# Static builds require that the fltk-1.3.5 source
 # tree is local to this directory. Please run "make fltk"
 # first to build the library before running "make".
 
 # you MUST have libxft-dev installed before compiling FLTK on linux
 # (otherwise you'll have ugly, non-resizable fonts)
 
-ifeq ($(wildcard ./fltk-1.3.3),)
+ifeq ($(wildcard ./fltk-1.3.5),)
   PLATFORM=linux_dynamic
 else
   PLATFORM=linux_static
@@ -21,7 +21,7 @@ NAME="EasySXB "
 VERSION=$(shell git describe)
 
 SRC_DIR=src
-INCLUDE=-I$(SRC_DIR) -Ifltk-1.3.3
+INCLUDE=-I$(SRC_DIR) -Ifltk-1.3.5
 
 ifeq ($(PLATFORM),linux_dynamic)
   LIBS=$(shell fltk-config --ldflags)
@@ -32,7 +32,7 @@ ifeq ($(PLATFORM),linux_dynamic)
 endif
 
 ifeq ($(PLATFORM),linux_static)
-  LIBS=$(shell ./fltk-1.3.3/fltk-config --use-images --ldstaticflags)
+  LIBS=$(shell ./fltk-1.3.5/fltk-config --use-images --ldstaticflags)
   HOST=
   CXX=g++
   CXXFLAGS=-O3 -DPACKAGE_STRING=\"$(NAME)$(VERSION)\" $(INCLUDE)
@@ -40,7 +40,7 @@ ifeq ($(PLATFORM),linux_static)
 endif
 
 ifeq ($(PLATFORM),mingw32)
-  LIBS=$(shell ./fltk-1.3.3/fltk-config --use-images --ldstaticflags)
+  LIBS=$(shell ./fltk-1.3.5/fltk-config --use-images --ldstaticflags)
   HOST=i686-w64-mingw32
   CXX=$(HOST)-g++
   CXXFLAGS=-O3 -static-libgcc -static-libstdc++ -DPACKAGE_STRING=\"$(NAME)$(VERSION)\" $(INCLUDE)
@@ -49,7 +49,7 @@ ifeq ($(PLATFORM),mingw32)
 endif
 
 ifeq ($(PLATFORM),mingw64)
-  LIBS=$(shell ./fltk-1.3.3/fltk-config --use-images --ldstaticflags)
+  LIBS=$(shell ./fltk-1.3.5/fltk-config --use-images --ldstaticflags)
   HOST=x86_64-w64-mingw32
   CXX=$(HOST)-g++
   CXXFLAGS=-O3 -static-libgcc -static-libstdc++ -DPACKAGE_STRING=\"$(NAME)$(VERSION)\" $(INCLUDE)
@@ -68,7 +68,7 @@ default: $(OBJ)
 	$(CXX) -o ./$(EXE) $(SRC_DIR)/Main.cxx $(OBJ) $(CXXFLAGS) $(LIBS)
 
 fltk:
-	@cd ./fltk-1.3.3; \
+	@cd ./fltk-1.3.5; \
 	make clean; \
 	./configure --host=$(HOST) --enable-localjpeg --enable-localzlib --enable-localpng --disable-xdbe; \
 	make; \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ http://sourceforge.net/projects/easysxb/
 
 ```$ cd EasySXB```
 
-Uncompress the FLTK-1.3.3 source package here.
+Uncompress the FLTK-1.3.5 source package here.
 
 The Makefile supports ```linux``` and ```mingw``` cross-compiler targets.
 (Edit the Makefile to choose.)
@@ -29,6 +29,6 @@ The Makefile supports ```linux``` and ```mingw``` cross-compiler targets.
 
 ### Libraries
 
- * FLTK-1.3.3
+ * FLTK-1.3.5
  * libxft-dev (required for font rendering)
 

--- a/src/Gui.cxx
+++ b/src/Gui.cxx
@@ -146,7 +146,7 @@ public:
         ctrl = Fl::event_ctrl() ? true : false;
 
         // misc keys
-        if(Fl::event_length > 0)
+        if(Fl::event_length != NULL)
         {
           Terminal::sendString(Fl::event_text());
         }


### PR DESCRIPTION
Thanks for EasySXB!

This PR fixes errors when compiling on macOS with Apple's LLVM implementation and the clang compiler. Upstream FLTK fixes a bunch of compile issues between 1.3.3 and 1.3.5 so this upgrades EasySXB to use the latest FLTK. It addresses one compile error in the EsaySXB source itself:
```
src/Gui.cxx:149:29: error: ordered comparison between pointer and zero
```

I've compiled it on macOS High Sierra and attached binaries to this release on my fork: https://github.com/relistan/EasySXB/releases/tag/v0.1.5